### PR TITLE
v05 of the draft

### DIFF
--- a/draft/draft-ietf-babel-yang-model.xml
+++ b/draft/draft-ietf-babel-yang-model.xml
@@ -371,9 +371,9 @@ reference: RFC XXXX ]]></artwork>
       <section title="Statistics Gathering Enabled">
         <t>In this example, interface eth0 is being configured for routing
         protocol Babel, and statistics gathering is enabled. For security,
-        HMAC-SHA256 is supported, with every Babel packets signed with the key
-        value provided, and every received Babel packet verified with the same
-        key value.<figure>
+        HMAC-SHA256 is supported. Every sent Babel packets is signed with the
+        key value provided, and every received Babel packet is verified with
+        the same key value.<figure>
             <artwork><![CDATA[
 INSERT_TEXT_FROM_FILE(../src/yang/example-babel-configuration-2.3.xml)
 ]]></artwork>

--- a/draft/draft-ietf-babel-yang-model.xml
+++ b/draft/draft-ietf-babel-yang-model.xml
@@ -370,7 +370,10 @@ reference: RFC XXXX ]]></artwork>
 
       <section title="Statistics Gathering Enabled">
         <t>In this example, interface eth0 is being configured for routing
-        protocol Babel, and statistics gathering is enabled.<figure>
+        protocol Babel, and statistics gathering is enabled. For security,
+        HMAC-SHA256 is supported, with every Babel packets signed with the key
+        value provided, and every received Babel packet verified with the same
+        key value.<figure>
             <artwork><![CDATA[
 INSERT_TEXT_FROM_FILE(../src/yang/example-babel-configuration-2.3.xml)
 ]]></artwork>

--- a/draft/draft-ietf-babel-yang-model.xml
+++ b/draft/draft-ietf-babel-yang-model.xml
@@ -10,7 +10,7 @@
 <?rfc inline="yes"?>
 <?rfc compact="yes"?>
 <?rfc subcompact="no"?>
-<rfc category="std" docName="draft-ietf-babel-yang-model-04" ipr="trust200902">
+<rfc category="std" docName="draft-ietf-babel-yang-model-05" ipr="trust200902">
   <front>
     <title abbrev="Babel YANG model">YANG Data Model for Babel</title>
 
@@ -65,7 +65,7 @@
       </address>
     </author>
 
-    <date day="18" month="October" year="2019"/>
+    <date day="3" month="January" year="2020"/>
 
     <area>Routing Area</area>
 

--- a/src/yang/example-babel-configuration-2.3.xml
+++ b/src/yang/example-babel-configuration-2.3.xml
@@ -20,12 +20,22 @@
 	<babel
 	    xmlns="urn:ietf:params:xml:ns:yang:ietf-babel">
 	  <enable>true</enable>
+	  <stats-enable>true</stats-enable>
 	  <interfaces>
 	    <reference>eth0</reference>
 	    <metric-algorithm>two-out-of-three</metric-algorithm>
 	    <split-horizon>true</split-horizon>
 	  </interfaces>
-	  <stats-enable>true</stats-enable>
+	  <mac>
+	    <name>hmac-sha256</name>
+	    <keys>
+	      <name>hmac-sha256-keys</name>
+	      <use-sign>true</use-sign>
+	      <use-verify>true</use-verify>
+	      <value>base64encodedvalue==</value>
+	      <algorithm>hmac-sha256</algorithm>
+	    </keys>
+	  </mac>
 	</babel>
       </control-plane-protocol>
     </control-plane-protocols>

--- a/src/yang/example-babel-configuration-2.3.xml
+++ b/src/yang/example-babel-configuration-2.3.xml
@@ -13,7 +13,8 @@
     <control-plane-protocols>
       <control-plane-protocol>
 	<type
-	    xmlns:babel="urn:ietf:params:xml:ns:yang:ietf-babel">babel:babel
+	    xmlns:babel=
+	    "urn:ietf:params:xml:ns:yang:ietf-babel">babel:babel
 	</type>
 	<name>name:babel</name>
 	<babel

--- a/src/yang/example-babel-configuration-2.4.xml
+++ b/src/yang/example-babel-configuration-2.4.xml
@@ -28,7 +28,8 @@
     <control-plane-protocols>
       <control-plane-protocol>
 	<type
-	    xmlns:babel="urn:ietf:params:xml:ns:yang:ietf-babel">babel:babel
+	    xmlns:babel=
+	    "urn:ietf:params:xml:ns:yang:ietf-babel">babel:babel
 	</type>
 	<name>name:babel</name>
 	<babel

--- a/src/yang/example-babel-configuration-2.5.xml
+++ b/src/yang/example-babel-configuration-2.5.xml
@@ -41,7 +41,8 @@
     <control-plane-protocols>
       <control-plane-protocol>
 	<type
-	    xmlns:babel="urn:ietf:params:xml:ns:yang:ietf-babel">babel:babel
+	    xmlns:babel=
+	    "urn:ietf:params:xml:ns:yang:ietf-babel">babel:babel
 	</type>
 	<name>name:babel</name>
 	<babel

--- a/src/yang/example-babel-configuration-2.6.xml
+++ b/src/yang/example-babel-configuration-2.6.xml
@@ -28,7 +28,8 @@
     <control-plane-protocols>
       <control-plane-protocol>
 	<type
-	    xmlns:babel="urn:ietf:params:xml:ns:yang:ietf-babel">babel:babel
+	    xmlns:babel=
+	    "urn:ietf:params:xml:ns:yang:ietf-babel">babel:babel
 	</type>
 	<name>name:babel</name>
 	<babel

--- a/src/yang/ietf-babel.yang
+++ b/src/yang/ietf-babel.yang
@@ -46,7 +46,7 @@ module ietf-babel {
      described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
      they appear in all capitals, as shown here.
 
-     Copyright (c) 2019 IETF Trust and the persons identified as
+     Copyright (c) 2020 IETF Trust and the persons identified as
      authors of the code. All rights reserved.
 
      Redistribution and use in source and binary forms, with or
@@ -368,19 +368,6 @@ module ietf-babel {
         description
           "Sequence number included in route updates for routes
            originated by this node.";
-        reference
-          "RFC ZZZZ: Babel Information Model, Section 3.1.";
-      }
-
-      leaf-list metric-comp-algorithms {
-        type identityref {
-          base "metric-comp-algorithms";
-        }
-        config false;
-        min-elements 1;
-        description
-          "List of cost compute algorithms supported by this
-           implementation of Babel.";
         reference
           "RFC ZZZZ: Babel Information Model, Section 3.1.";
       }

--- a/src/yang/ietf-babel.yang
+++ b/src/yang/ietf-babel.yang
@@ -72,14 +72,44 @@ module ietf-babel {
    */
   feature two-out-of-three-supported {
     description
-      "This implementation can support two-out-of-three metric
+      "This implementation supports two-out-of-three metric
        comp algorithm.";
   }
 
   feature etx-supported {
     description
-      "This implementation can support Expected Transmission Count
+      "This implementation supports Expected Transmission Count
        (ETX) metric comp algorithm.";
+  }
+
+  feature mac-supported {
+    description
+      "This implementation supports MAC based security.";
+  }
+
+  feature dtls-supported {
+    description
+      "This implementation supports DTLS based security.";
+  }
+
+  feature hmac-sha256-supported {
+    description
+      "This implementation supports hmac-sha256 MAC algorithm.";
+  }
+
+  feature blake2s-supported {
+    description
+      "This implementation supports blake2 MAC algorithm.";
+  }
+
+  feature x-509-supported {
+    description
+      "This implementation supports x-509 certificate type.";
+  }
+
+  feature raw-public-key-supported {
+    description
+      "This implementation supports raw-public-key certificate type.";
   }
 
   /*
@@ -106,29 +136,6 @@ module ietf-babel {
   }
 
   /*
-   * Babel security type identities
-   */
-  identity security-supported {
-    description
-      "Base identity from which all Babel security types are
-       derived.";
-  }
-
-  identity mac {
-    base security-supported;
-    description
-      "Keyed MAC supported.";
-  }
-
-  identity dtls {
-    base security-supported;
-    description
-      "Datagram Transport Layer Security (DTLS) supported.";
-    reference
-      "RFC 6347, Datagram Transport Layer Security Version 1.2.";
-  }
-
-  /*
    * Babel MAC algorithms identities.
    */
   identity mac-algorithms {
@@ -138,6 +145,8 @@ module ietf-babel {
 
   identity hmac-sha256 {
     base mac-algorithms;
+    if-feature mac-supported;
+    if-feature hmac-sha256-supported;
     description
       "HMAC-SHA256 algorithm supported.";
     reference
@@ -147,6 +156,8 @@ module ietf-babel {
 
   identity blake2s {
     base mac-algorithms;
+    if-feature mac-supported;
+    if-feature blake2s-supported;
     description
       "BLAKE2s algorithm supported.";
     reference
@@ -164,12 +175,16 @@ module ietf-babel {
 
   identity x-509 {
     base dtls-cert-types;
+    if-feature dtls-supported;
+    if-feature x-509-supported;
     description
       "X.509 certificate type.";
   }
 
   identity raw-public-key {
     base dtls-cert-types;
+    if-feature dtls-supported;
+    if-feature raw-public-key-supported;
     description
       "Raw Public Key type.";
   }
@@ -368,42 +383,6 @@ module ietf-babel {
         description
           "Sequence number included in route updates for routes
            originated by this node.";
-        reference
-          "RFC ZZZZ: Babel Information Model, Section 3.1.";
-      }
-
-      leaf-list security-supported {
-        type identityref {
-          base "security-supported";
-        }
-        config false;
-        min-elements 1;
-        description
-          "List of supported security mechanisms.";
-        reference
-          "RFC ZZZZ: Babel Information Model, Section 3.1.";
-      }
-
-      leaf-list mac-algorithms {
-        type identityref {
-          base mac-algorithms;
-        }
-        config false;
-        description
-          "List of supported MAC computation algorithms. Possible
-           values include 'HMAC-SHA256', 'BLAKE2s'.";
-        reference
-          "RFC ZZZZ: Babel Information Model, Section 3.1.";
-      }	  
-
-      leaf-list dtls-cert-types {
-        type identityref {
-          base dtls-cert-types;
-        }
-        config false;
-        description
-          "List of supported DTLS certificate types. Possible values
-           include 'X.509' and 'RawPublicKey'.";
         reference
           "RFC ZZZZ: Babel Information Model, Section 3.1.";
       }


### PR DESCRIPTION
This PR incorporates the changes needed to get the column width in the examples down to 72 or under. It also addresses the issue of removing metric-comp-algorithm from babel-information-obj, as there is no way in YANG to enforce it. It should have been removed when we introduced support for metric-comp-algorithms as features.

Using the feature statement, the implementation can declare which of the metric-comp-algorithms it supports, which was the intention of having a leaf-list of those algorithms in the first place. As such, we do not need the leaf-list anymore.