### PR TITLE
Fixing of NULL representation in the model.

### DIFF
--- a/draft/draft-ietf-babel-yang-model.xml
+++ b/draft/draft-ietf-babel-yang-model.xml
@@ -64,7 +64,7 @@
       </address>
     </author>
 
-    <date day="15" month="August" year="2021"/>
+    <date day="17" month="September" year="2021"/>
 
     <area>Routing Area</area>
 

--- a/src/yang/ietf-babel.yang
+++ b/src/yang/ietf-babel.yang
@@ -295,7 +295,7 @@ module ietf-babel {
           "The metric with which this route was advertised by the
            neighbor, or maximum value (infinity) to indicate the
            route was recently retracted and is temporarily
-           unreachable. This metric will be NULL (empty) if the
+           unreachable. This metric will be NULL if the
            route was not received from a neighbor but instead was
            injected through means external to the Babel routing 
            protocol. At least one of calculated-metric or 
@@ -337,12 +337,17 @@ module ietf-babel {
 
       leaf next-hop {
         type union {
-          type empty;
+          type enumeration {
+            enum null {
+              description
+                "Route has no next-hop address.";
+            }
+          }
           type inet:ip-address;
         }
         description
           "The next-hop address of this route. This will be NULL
-           (empty) if this route has no next-hop address.";
+           if this route has no next-hop address.";
         reference
           "RFC 9046: Babel Information Model, Section 3.6.";
       }
@@ -868,7 +873,7 @@ module ietf-babel {
               "Expected multicast Hello sequence number of next Hello
                to be received from this neighbor; if multicast Hello
                packets are not expected, or processing of multicast
-               packets is not enabled, this MUST be NULL (empty).";
+               packets is not enabled, this MUST be NULL.";
             reference
               "RFC 9046: Babel Information Model, Section 3.5.";
           }
@@ -889,7 +894,7 @@ module ietf-babel {
               "Expected unicast Hello sequence number of next Hello
                to be received from this neighbor; if unicast Hello
                packets are not expected, or processing of unicast
-               packets is not enabled, this MUST be NULL (empty).";
+               packets is not enabled, this MUST be NULL.";
             reference
               "RFC 9046: Babel Information Model, Section 3.5.";
           }
@@ -908,7 +913,7 @@ module ietf-babel {
             description
               "The current sequence number in use for unicast Hellos
                sent to this neighbor. If unicast Hellos are not being
-               sent, this MUST be NULL (empty).";
+               sent, this MUST be NULL.";
             reference
               "RFC 9046: Babel Information Model, Section 3.5.";
           }

--- a/src/yang/ietf-babel.yang
+++ b/src/yang/ietf-babel.yang
@@ -282,12 +282,20 @@ module ietf-babel {
       }
 
       leaf received-metric {
-        type uint16;
+        type union {
+          type enumeration {
+            enum null {
+              description
+                "Route was not received from a neighbor.";
+            }
+          }
+          type uint16;
+        }
         description
           "The metric with which this route was advertised by the
            neighbor, or maximum value (infinity) to indicate the
            route was recently retracted and is temporarily
-           unreachable. This metric will be NULL (no value) if the
+           unreachable. This metric will be NULL (empty) if the
            route was not received from a neighbor but instead was
            injected through means external to the Babel routing 
            protocol. At least one of calculated-metric or 
@@ -298,7 +306,15 @@ module ietf-babel {
       }
 
       leaf calculated-metric {
-        type uint16;
+        type union {
+          type enumeration {
+            enum null {
+              description
+                "Route has not been calculated.";
+            }
+          }
+          type uint16;
+        }
         description
           "A calculated metric for this route. How the metric is
            calculated is implementation-specific. Maximum value
@@ -320,10 +336,13 @@ module ietf-babel {
       }
 
       leaf next-hop {
-        type inet:ip-address;
+        type union {
+          type empty;
+          type inet:ip-address;
+        }
         description
-          "The next-hop address of this route. This will be NULL if
-           this route has no next-hop address.";
+          "The next-hop address of this route. This will be NULL
+           (empty) if this route has no next-hop address.";
         reference
           "RFC 9046: Babel Information Model, Section 3.6.";
       }
@@ -834,35 +853,62 @@ module ietf-babel {
           }
 
           leaf exp-mcast-hello-seqno {
-            type uint16;
+            type union {
+              type enumeration {
+                enum null {
+                  description
+                    "Multicast Hello packets are not expected, or
+                     processing of multicast packets is not
+                     enabled.";
+                }
+              }
+              type uint16;
+            }
             description
               "Expected multicast Hello sequence number of next Hello
                to be received from this neighbor; if multicast Hello
                packets are not expected, or processing of multicast
-               packets is not enabled, this MUST be NULL.";
+               packets is not enabled, this MUST be NULL (empty).";
             reference
               "RFC 9046: Babel Information Model, Section 3.5.";
           }
 
           leaf exp-ucast-hello-seqno {
-            type uint16;
-            default "0";
+            type union {
+              type enumeration {
+                enum null {
+                  description
+                    "Unicast Hello packets are not expected, or
+                     processing of unicast packets is not enabled.";
+                }
+              }
+              type uint16;
+            }
+            default null;
             description
               "Expected unicast Hello sequence number of next Hello
                to be received from this neighbor; if unicast Hello
                packets are not expected, or processing of unicast
-               packets is not enabled, this MUST be NULL.";
+               packets is not enabled, this MUST be NULL (empty).";
             reference
               "RFC 9046: Babel Information Model, Section 3.5.";
           }
 
           leaf ucast-hello-seqno {
-            type uint16;
-            default "0";
+            type union {
+              type enumeration {
+                enum null {
+                  description
+                    "Unicast Hello packets are not being sent.";
+                }
+              }
+              type uint16;
+            }
+            default null;
             description
               "The current sequence number in use for unicast Hellos
                sent to this neighbor. If unicast Hellos are not being
-               sent, this MUST be NULL.";
+               sent, this MUST be NULL (empty).";
             reference
               "RFC 9046: Babel Information Model, Section 3.5.";
           }


### PR DESCRIPTION
YANG does not define a NULL type. The only way to represent a NULL value is to define a type union, where one of the values is an enumeration called null.